### PR TITLE
トップのレイアウト崩れ直しましたよ

### DIFF
--- a/src/pages/top/index.js
+++ b/src/pages/top/index.js
@@ -1,4 +1,4 @@
-import { baseImgPath } from '../../constants';
+import { baseImgPath } from '../../../constants;'
 import { repeat } from 'lit-html/directives/repeat';
 import { html, LitElement, svg } from 'lit-element';
 import '../../components/button';

--- a/src/pages/top/index.pcss
+++ b/src/pages/top/index.pcss
@@ -22,18 +22,23 @@
 
 .main {
   display: flex;
+  justify-content: center;
   width: 80%;
-  margin: 0 auto 10px;
+  margin: 0 auto 20px;
   animation: fadeIn 6s ease;
 }
 
 .main__contents {
-  width: 33%;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  max-width: 320px;
 }
 
 .main__item {
-  height: 26%;
-  margin: 16px 8px;
+  width: 90px;
+  height: 90px;
+  margin: 0 8px 16px;
   border-radius: 20px;
   overflow: hidden;
 }


### PR DESCRIPTION
```
${repeat(
            __imgPaths,
            __imgPath => {
              return html`
              <div class="main__item">
                <img class="main__image" src="${baseImgPath}/${__imgPath}">
              </div>
            `
          })}
```
でもちゃんと3つずつ並ぶよ　多分

<img width="1096" alt="スクリーンショット 2019-12-15 3 15 57" src="https://user-images.githubusercontent.com/32506339/70852819-3d20e280-1ee9-11ea-92af-cd9fb2bf5be1.png">
