### PR TITLE
デザイン修正

### DIFF
--- a/src/pages/sheet/index.pcss
+++ b/src/pages/sheet/index.pcss
@@ -4,6 +4,7 @@
 .list {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .list-item {

--- a/src/pages/store/index.pcss
+++ b/src/pages/store/index.pcss
@@ -8,7 +8,7 @@ a100-title {
 .list {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: space-between;
 }
 
 .list-item {


### PR DESCRIPTION
justify-content: center;
だと中央によってしまうので、space-betweeeeeeeeeeeeeeeenにしました

(tablet&pc　にしか関係ないんだけどね(・ω<) ﾃﾍﾍﾟﾛ)